### PR TITLE
this missing space is breaking a string template

### DIFF
--- a/lms/templates/jobs/job_table.html
+++ b/lms/templates/jobs/job_table.html
@@ -25,7 +25,7 @@
             const latitude = position.coords.latitude;
             const longitude = position.coords.longitude;
             if (latitude && longitude) {
-              const baseUrl = "$ {settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}table";
+              const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}table";
               const microserviceUrl = baseUrl + "/" + latitude + "/" + longitude;
 
               $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);


### PR DESCRIPTION
we were setting an iframe to a 404'd URL, which was navigating the page away -- but ONLY if you had agreed to geolocation beforehand.  Really NBD.