### PR TITLE
bug: Turn off async for accredible ajax call to prevent it to call the api twice

### DIFF
--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -220,6 +220,7 @@ ${gymcms.render('final-exam-modal')}
         $.ajax({
           type:     'POST',
           url:      '/accredible/request_certificate',
+          async:     false,
           data:     {'course_id': $$course_id},
           success:  function(data) {
           }


### PR DESCRIPTION
After upgrade around 33% of accredible credentials API calls happened twice, By turning off the async we make the client to call the accredible, wait and finish the execution. I did test this on staging and after turning off the async duplication didn't happen anymore