### PR TITLE
[Release]: Add new Take 5 Tutorial path

### DIFF
--- a/lms/templates/static_templates/courses/take5/taking-your-portfolio-case-studies-to-the-next-level.html
+++ b/lms/templates/static_templates/courses/take5/taking-your-portfolio-case-studies-to-the-next-level.html
@@ -1,0 +1,11 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../../../main.html" />
+<%namespace name="gymcms" file="../../../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Taking Your Portfolio Case Studies to the Next Level")}</%block>
+
+<%block name="gym_head_meta">
+  ${gymcms.render('courses/take5/gym-5056/meta')}
+</%block>
+
+${gymcms.render('courses/take5/GYM-5056')}


### PR DESCRIPTION
Also requires config update: https://github.com/appsembler/aquent-dev-configs/pull/15/files


which basically adds one line to the URL Link Map:
```
COURSES/TAKE5/TAKING-YOUR-PORTFOLIO-CASE-STUDIES-TO-THE-NEXT-LEVEL: "courses/take5/taking-your-portfolio-case-studies-to-the-next-level.html"
```

See https://github.com/gymnasium/tracker/issues/314