### PR TITLE
[Feature]: Add holiday card pages/directories

### DIFF
--- a/lms/templates/static_templates/holiday-card.html
+++ b/lms/templates/static_templates/holiday-card.html
@@ -1,0 +1,11 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Holiday Card")}</%block>
+
+<%block name="gym_head_meta">
+  ${gymcms.render('holiday-card/meta')}
+</%block>
+
+${gymcms.render('holiday-card')}

--- a/lms/templates/static_templates/holiday-card/2021.html
+++ b/lms/templates/static_templates/holiday-card/2021.html
@@ -1,0 +1,11 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../../main.html" />
+<%namespace name="gymcms" file="../../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("2021")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('holiday-card/2021/meta')}
+</%block>
+
+${gymcms.render('holiday-card/2021')}

--- a/lms/templates/static_templates/holiday-card/2022.html
+++ b/lms/templates/static_templates/holiday-card/2022.html
@@ -1,0 +1,11 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../../main.html" />
+<%namespace name="gymcms" file="../../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("2022")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('holiday-card/2022/meta')}
+</%block>
+
+${gymcms.render('holiday-card/2022')}


### PR DESCRIPTION
Adding the following paths to gymcms/theme:
- `/happy-new-year`
- `/holiday-card`
- `/holiday-card/2022`
- `/holiday-card/2021`
- `/holiday-card/2020`


See https://github.com/gymnasium/tracker/issues/315


Needs config update: adds new paths to URL LINK MAP:

```
  HAPPY-NEW-YEAR: "happy-new-year.html"
  HOLIDAY-CARD: "holiday-card.html"
  HOLIDAY-CARD/2022: "holiday-card/2022.html"
  HOLIDAY-CARD/2021: "holiday-card/2021.html"
  HOLIDAY-CARD/2020: "holiday-card/2020.html"
```
See: https://github.com/appsembler/aquent-dev-configs/pull/19
